### PR TITLE
Add support for prepared raw data

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -303,6 +303,8 @@ queryize.deleteFrom('eventlog')
 						
 						<li class="private "><a href="#functionarrayFromArguments"><span class="name">arrayFromArguments</span></a></li>
 						
+						<li class="private "><a href="#method_handleRawSubquery"><span class="name">_handleRawSubquery</span></a></li>
+						
 							<li class=""><a href="#constructorqueryize"><span class="name">queryize</span></a></li>
 						<li><ul class="nav ">
 						
@@ -2236,6 +2238,22 @@ Accepts either an array of <code>columns</code>, or multiple <code>column</code>
 							<div class="panel-footer"><strong>Returns: </strong> query <em class="pull-right">&lt;p&gt;Exports &lt;code&gt;this&lt;/code&gt; for chaining&lt;/p&gt;</em></div>
 						</div>
 						<div class="signature panel panel-default">
+							<div class="panel-heading"><div class="panel-title">query.set(column, rawValue)</div></div>
+							<ol class="list-group">
+								<li class="list-group-item">
+									<strong>column</strong> string
+									
+									
+								</li>
+								<li class="list-group-item">
+									<strong>rawValue</strong> [object Object]
+									
+									<p>{raw: string, data?: Array&lt;string|number&gt;|string|number}</p>
+								</li>
+							</ol>
+							<div class="panel-footer"><strong>Returns: </strong> query <em class="pull-right">&lt;p&gt;Exports &lt;code&gt;this&lt;/code&gt; for chaining&lt;/p&gt;</em></div>
+						</div>
+						<div class="signature panel panel-default">
 							<div class="panel-heading"><div class="panel-title">query.set(data, [modifier])</div></div>
 							<ol class="list-group">
 								<li class="list-group-item">
@@ -2259,6 +2277,9 @@ Accepts either an array of <code>columns</code>, or multiple <code>column</code>
 // DATA: ['Susan', 'Sto Helet']</code></pre>
 							<pre class="panel-body prettyprint"><code class="language-javascript">query.set('lastLogin', {raw:'NOW()'});
 // SET lastLogin = NOW()</code></pre>
+							<pre class="panel-body prettyprint"><code class="language-javascript">query.set('bgColour', {raw:'CONV(?, 16, 2)', data:'fff'});
+// SET bgColour = CONV(?, 16, 2)
+// DATA: ['fff']</code></pre>
 							<div class="panel-footer"><strong>Returns: </strong> query <em class="pull-right">&lt;p&gt;Exports &lt;code&gt;this&lt;/code&gt; for chaining&lt;/p&gt;</em></div>
 						</div>
 
@@ -2284,7 +2305,7 @@ Accepts either an array of <code>columns</code>, or multiple <code>column</code>
   if (typeof value !== 'undefined') {
     var column = clause;
     if (value && typeof value === 'object' && typeof value.raw === 'string') {
-      clause = clause + ' = ' + value.raw;
+      clause += ' = ' + self._handleRawSubquery(value);
     } else {
       if (!isValidPrimative(value)) {
         throw new TypeError('Unknown data type in set clause');
@@ -2323,6 +2344,7 @@ Example: <code>INSERT INTO user SET firstname=?, lastname=?</code></p>
 <p>Example: <code>INSERT INTO user (firstname, lastname) VALUES (?,?), (?,?)</code></p>
 <p>This format is more performant for inserting multiple uniform data sets, but is less flexible as all the columns must be known upfront. If row contents are provided as arrays, the column order must be defined before calling <code>query.addRow</code>.  If keyed objects are provided then Queryize will use the keys to identify the column names to use.</p>
 <p>Any rows with missing columns will receive <code>NULL</code> for the column's contents.</p>
+<p>You can use SQL functions with the use of raw subqueries. If you want to pass untrusted data within a subquery, replace it with a question mark (?) and pass the untrusted data outside of the query, as the example below shows.</p>
 						<h3>Usage:</h3>
 						<div class="signature panel panel-default">
 							<div class="panel-heading"><div class="panel-title">query.addRow(data)</div></div>
@@ -2347,9 +2369,10 @@ Example: <code>INSERT INTO user SET firstname=?, lastname=?</code></p>
   .into('users')
   .addRow({name: 'John Smith', email: 'jsmith@example.com'})
   .addRow({name: 'Jane Doe', email: 'jdoe@example.com', date_created: {raw:'NOW()'}})
+  .addRow({name: {raw: 'UPPER(?)', data : 'Alice Fox'}, email: {raw:'CONCAT(?, "@", ?)', data: ['afox', 'example.com', 'ignored']}})
   .compile()
-// INSERT INTO users (name, email, date_created) VALUES (?, ?, NULL), (?, ?, NOW())
-// DATA: ['John Smith', 'jsmith@example.com', 'Jane Doe', 'jdoe@example.com']</code></pre>
+// INSERT INTO users (name, email, date_created) VALUES (?, ?, NULL), (?, ?, NOW()), (UPPER(?), CONCAT(?, "@", ?), NULL)
+// DATA: ['John Smith', 'jsmith@example.com', 'Jane Doe', 'jdoe@example.com', 'Alice Fox', 'afox', 'example.com']</code></pre>
 							<div class="panel-footer"><strong>Returns: </strong> query <em class="pull-right">&lt;p&gt;Exports &lt;code&gt;this&lt;/code&gt; for chaining&lt;/p&gt;</em></div>
 						</div>
 
@@ -3650,6 +3673,45 @@ MUST be called via .apply</p>
   }
   return args;
 }</code></pre>
+							</div>
+						</div>
+					</div>
+				
+					<div id="method_handleRawSubquery" style="position:relative;top:-60px;"></div>
+					<div class="piece private ">
+						<div class="page-header"><h2>_handleRawSubquery <small></small></h2></div>
+					
+						<p>Helper function to handle raw subqueries</p>
+						<h3>Usage:</h3>
+						<div class="signature panel panel-default">
+							<div class="panel-heading"><div class="panel-title">_handleRawSubquery(value)</div></div>
+							<ol class="list-group">
+								<li class="list-group-item">
+									<strong>value</strong> [object Object]
+									
+									
+								</li>
+							</ol>
+						</div>
+
+
+						<div class="codeview panel panel-default">
+							<div class="panel-heading" data-toggle="collapse" data-target="#method_handleRawSubquery + .piece .panel-collapse">
+								<i class="ico-embed"></i> View Code
+							</div>
+							<div class="panel-collapse collapse">
+								<pre class="panel-body prettyprint"><code class="language-javascript">query._handleRawSubquery = function (value) {
+  var self = this;
+  if ('data' in value) {
+    if (!Array.isArray(value.data)) {
+      value.data = [ value.data ];
+    }
+    value.raw = value.data.reduce(function (raw, data) {
+      return raw.replace('?', self.createBinding(data));
+    }, value.raw);
+  }
+  return value.raw;
+};</code></pre>
 							</div>
 						</div>
 					</div>

--- a/lib/mutators.js
+++ b/lib/mutators.js
@@ -908,6 +908,11 @@ query.limit = function limit (max, offset) {
  * @param {string|number} value
  * @return {query} Exports `this` for chaining
  *
+ * @signature query.set(column, rawValue)
+ * @param {string} column
+ * @param {{raw: string, data: any[]|any}} rawValue {raw: string, data?: Array<string|number>|string|number}
+ * @return {query} Exports `this` for chaining
+ *
  * @signature query.set(data, [modifier])
  * @param {Object} data A plain object collection of column/value pairs
  * @param {string} modifier [description]
@@ -992,6 +997,8 @@ query.set = function set (clause, value, modifier) {
  *
  * Any rows with missing columns will receive `NULL` for the column's contents.
  *
+ * You can use SQL functions with the use of raw subqueries. If you want to pass untrusted data within a subquery, replace it with a question mark (?) and pass the untrusted data outside of the query, as the example below shows.
+ *
  * @memberOf query
  * @category Insertion & Replacement
  *
@@ -1015,9 +1022,10 @@ query.set = function set (clause, value, modifier) {
  *   .into('users')
  *   .addRow({name: 'John Smith', email: 'jsmith@example.com'})
  *   .addRow({name: 'Jane Doe', email: 'jdoe@example.com', date_created: {raw:'NOW()'}})
+ *   .addRow({name: {raw: 'UPPER(?)', data : 'Alice Fox'}, email: {raw:'CONCAT(?, "@", ?)', data: ['afox', 'example.com', 'ignored']}})
  *   .compile()
- * // INSERT INTO users (name, email, date_created) VALUES (?, ?, NULL), (?, ?, NOW())
- * // DATA: ['John Smith', 'jsmith@example.com', 'Jane Doe', 'jdoe@example.com']
+ * // INSERT INTO users (name, email, date_created) VALUES (?, ?, NULL), (?, ?, NOW()), (UPPER(?), CONCAT(?, "@", ?), NULL)
+ * // DATA: ['John Smith', 'jsmith@example.com', 'Jane Doe', 'jdoe@example.com', 'Alice Fox', 'afox', 'example.com']
  */
 query.addRow = function addRow (data) {
 	var row, columns;
@@ -1987,7 +1995,7 @@ function arrayFromArguments () {
 /**
  * Helper function to handle raw subqueries
  * @private
- * @param {{raw: string, data?: any[]|any}} value
+ * @param {{raw: string, data: any[]|any}} value
  * @returns {string}
  */
 query._handleRawSubquery = function (value) {

--- a/lib/mutators.js
+++ b/lib/mutators.js
@@ -930,6 +930,11 @@ query.limit = function limit (max, offset) {
  * @example
  * query.set('lastLogin', {raw:'NOW()'});
  * // SET lastLogin = NOW()
+ *
+ * @example
+ * query.set('bgColour', {raw:'CONV(?, 16, 2)', data:'fff'});
+ * // SET bgColour = CONV(?, 16, 2)
+ * // DATA: ['fff']
  */
 query.set = function set (clause, value, modifier) {
 	var self = this;
@@ -947,7 +952,7 @@ query.set = function set (clause, value, modifier) {
 	if (typeof value !== 'undefined') {
 		var column = clause;
 		if (value && typeof value === 'object' && typeof value.raw === 'string') {
-			clause = clause + ' = ' + value.raw;
+			clause += ' = ' + self._handleRawSubquery(value);
 		} else {
 			if (!isValidPrimative(value)) {
 				throw new TypeError('Unknown data type in set clause');
@@ -1547,8 +1552,13 @@ var builders = query._builders = {
 	'insertMultiple': function buildMultiRowInsert () {
 		// This is a special builder function which returns a tuple of query + data instead of just a query string.
 
+		var self = this;
 		var data = [];
-		var q = [ (this._attributes.insertMode || 'INSERT') + ' INTO', this._buildTableName(), '(' ];
+		var q = [
+			(this._attributes.insertMode || 'INSERT') + ' INTO',
+			this._buildTableName(),
+			'('
+		];
 		var columns;
 
 		if (this._attributes.columns.length) {
@@ -1571,7 +1581,7 @@ var builders = query._builders = {
 				}
 
 				if (typeof row[column] === 'object' && typeof row[column].raw === 'string') {
-					return row[column].raw;
+					return self._handleRawSubquery(row[column]);
 				}
 
 				if (row[column] instanceof Date) {
@@ -1973,3 +1983,22 @@ function arrayFromArguments () {
 	}
 	return args;
 }
+
+/**
+ * Helper function to handle raw subqueries
+ * @private
+ * @param {{raw: string, data?: any[]|any}} value
+ * @returns {string}
+ */
+query._handleRawSubquery = function (value) {
+	var self = this;
+	if ('data' in value) {
+		if (!Array.isArray(value.data)) {
+			value.data = [ value.data ];
+		}
+		value.raw = value.data.reduce(function (raw, data) {
+			return raw.replace('?', self.createBinding(data));
+		}, value.raw);
+	}
+	return value.raw;
+};

--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
   },
   "homepage": "http://queryizejs.com/",
   "devDependencies": {
+    "babel-eslint": "^8.2.2",
     "commonmark": "^0.28.0",
     "dox": "^0.9.0",
     "eslint": "~4.11.0",
+    "eslint-config-defaults": "^9.0.0",
+    "eslint-plugin-react": "^7.7.0",
     "handlebars": "^4.0.5",
     "mktmpio": "~1.0.0-9",
     "mysql": "*",

--- a/tests/unit/insert.js
+++ b/tests/unit/insert.js
@@ -1,9 +1,10 @@
-
 var test = require('tap').test;
 var queryize = require('../../');
 
-test('insert without set throws error', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('insert without set throws error', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	test.throws(function () {
 		q.compile();
@@ -12,8 +13,10 @@ test('insert without set throws error', (test) => {
 	test.end();
 });
 
-test('basic insert', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('basic insert', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set('name', 'bob');
 
@@ -25,8 +28,10 @@ test('basic insert', (test) => {
 	test.end();
 });
 
-test('basic insert with database', (test) => {
-	var q = queryize().insert().intoDatabase('test', 'users', 'u');
+test('basic insert with database', test => {
+	var q = queryize()
+		.insert()
+		.intoDatabase('test', 'users', 'u');
 
 	q.set('name', 'bob');
 
@@ -38,8 +43,10 @@ test('basic insert with database', (test) => {
 	test.end();
 });
 
-test('basic insert with object to set', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('basic insert with object to set', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({ name: 'bob' });
 
@@ -51,8 +58,10 @@ test('basic insert with object to set', (test) => {
 	test.end();
 });
 
-test('basic insert with multiple-keyed object to set', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('basic insert with multiple-keyed object to set', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({
 		firstname: 'Bojack',
@@ -67,8 +76,10 @@ test('basic insert with multiple-keyed object to set', (test) => {
 	test.end();
 });
 
-test('insert with set value of object throws error', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('insert with set value of object throws error', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	test.throws(function () {
 		q.set({ name: { blah: 1 } });
@@ -77,8 +88,10 @@ test('insert with set value of object throws error', (test) => {
 	test.end();
 });
 
-test('insert with a date value', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('insert with a date value', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({ lastlogin: new Date('2012-01-01') });
 
@@ -90,8 +103,10 @@ test('insert with a date value', (test) => {
 	test.end();
 });
 
-test('insert with a number value', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('insert with a number value', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({ lastlogin: 6 });
 
@@ -103,8 +118,10 @@ test('insert with a number value', (test) => {
 	test.end();
 });
 
-test('insert with a boolean value', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('insert with a boolean value', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({ lastlogin: true });
 
@@ -116,8 +133,10 @@ test('insert with a boolean value', (test) => {
 	test.end();
 });
 
-test('set throws an error if no parameters provided', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('set throws an error if no parameters provided', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	test.throws(function () {
 		q.set();
@@ -126,8 +145,10 @@ test('set throws an error if no parameters provided', (test) => {
 	test.end();
 });
 
-test('set overwrites', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('set overwrites', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({ lastlogin: 6 });
 	q.set({ lastlogin: 7 });
@@ -140,8 +161,10 @@ test('set overwrites', (test) => {
 	test.end();
 });
 
-test('set raw value', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('set raw value', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.set({ lastlogin: { raw: 'NOW()' } });
 
@@ -153,8 +176,40 @@ test('set raw value', (test) => {
 	test.end();
 });
 
-test('insert called with arguments', (test) => {
-	var q = queryize().insert({ value: false }).into('users', 'u');
+test('set raw value with prepared parameter', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
+
+	q.set({ lastlogin: { raw: 'CONV(?, 16, 2)', data: 'ffaaff' } });
+
+	test.deepEqual(q.compile(), {
+		query: 'INSERT INTO `users` u SET lastlogin = CONV(?, 16, 2)',
+		data: [ 'ffaaff' ]
+	});
+
+	test.end();
+});
+
+test('set raw value with prepared parameter', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
+
+	q.set({ lastlogin: { raw: 'CONV(?, ?, 2)', data: [ 'abcd', 25, 'ignored' ] } });
+
+	test.deepEqual(q.compile(), {
+		query: 'INSERT INTO `users` u SET lastlogin = CONV(?, ?, 2)',
+		data: [ 'abcd', 25 ]
+	});
+
+	test.end();
+});
+
+test('insert called with arguments', test => {
+	var q = queryize()
+		.insert({ value: false })
+		.into('users', 'u');
 
 	test.deepEqual(q.compile(), {
 		query: 'INSERT INTO `users` u SET value = FALSE',
@@ -164,8 +219,10 @@ test('insert called with arguments', (test) => {
 	test.end();
 });
 
-test('replace into', (test) => {
-	var q = queryize().replace({ value: false }).into('users', 'u');
+test('replace into', test => {
+	var q = queryize()
+		.replace({ value: false })
+		.into('users', 'u');
 
 	test.deepEqual(q.compile(), {
 		query: 'REPLACE INTO `users` u SET value = FALSE',
@@ -175,8 +232,10 @@ test('replace into', (test) => {
 	test.end();
 });
 
-test('insert with ignore', (test) => {
-	var q = queryize().insertIgnore({ value: false }).into('users', 'u');
+test('insert with ignore', test => {
+	var q = queryize()
+		.insertIgnore({ value: false })
+		.into('users', 'u');
 
 	test.deepEqual(q.compile(), {
 		query: 'INSERT IGNORE INTO `users` u SET value = FALSE',
@@ -186,8 +245,10 @@ test('insert with ignore', (test) => {
 	test.end();
 });
 
-test('multi-insert', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('multi-insert', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.addRow({ lastlogin: 6 });
 	q.addRow({ lastlogin: 10 });
@@ -202,8 +263,10 @@ test('multi-insert', (test) => {
 	test.end();
 });
 
-test('multi-insert replace', (test) => {
-	var q = queryize().replace().into('users', 'u');
+test('multi-insert replace', test => {
+	var q = queryize()
+		.replace()
+		.into('users', 'u');
 
 	q.addRow({ lastlogin: 6 });
 	q.addRow({ lastlogin: 10 });
@@ -218,8 +281,10 @@ test('multi-insert replace', (test) => {
 	test.end();
 });
 
-test('multi-insert, multi-column', (test) => {
-	var q = queryize().insert().into('users');
+test('multi-insert, multi-column', test => {
+	var q = queryize()
+		.insert()
+		.into('users');
 
 	q.addRow({ name: 'John Doe', age: 26 });
 	q.addRow({ name: 'Bob Smith', age: 32 });
@@ -234,8 +299,10 @@ test('multi-insert, multi-column', (test) => {
 	test.end();
 });
 
-test('multi-insert w/ raw value', (test) => {
-	var q = queryize().insert().into('users', 'u');
+test('multi-insert w/ raw value', test => {
+	var q = queryize()
+		.insert()
+		.into('users', 'u');
 
 	q.addRow({ lastlogin: { raw: 'NOW()' } });
 	q.addRow({ lastlogin: 10 });
@@ -250,8 +317,10 @@ test('multi-insert w/ raw value', (test) => {
 	test.end();
 });
 
-test('multi-insert, adding arrays', (test) => {
-	var q = queryize().insert().into('users');
+test('multi-insert, adding arrays', test => {
+	var q = queryize()
+		.insert()
+		.into('users');
 
 	q.columns('name', 'age');
 	q.addRow([ 'John Doe', 26 ]);
@@ -267,8 +336,10 @@ test('multi-insert, adding arrays', (test) => {
 	test.end();
 });
 
-test('multi-insert, adding arrays w/o columns throws', (test) => {
-	var q = queryize().insert().into('users');
+test('multi-insert, adding arrays w/o columns throws', test => {
+	var q = queryize()
+		.insert()
+		.into('users');
 
 	test.throws(function () {
 		q.addRow([ 'John Doe', 26 ]);


### PR DESCRIPTION
Fixes [#21](https://github.com/Twipped/QueryizeJS/issues/21)

Feature added: Allow the use of untrusted data in raw subqueries.

```js
const data = `some untrusted user input`;
queryize()
  .table("table")
  .update()
  .set("jsonArray", { raw: "JSON_ARRAY_APPEND(jsonArray, '$', ?)", data });
```

> Sorry about all the unnecessary changes in the test file, my editor did it automatically.